### PR TITLE
Fix argparser code selection

### DIFF
--- a/argmark/argmark.py
+++ b/argmark/argmark.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from typing import List
-
+from inspect import cleandoc
 from mdutils.mdutils import MdUtils
 
 
@@ -23,31 +23,6 @@ def inline_code(code: str) -> str:
     return f"`{code}`"
 
 
-def get_indent(line: str) -> int:
-    """
-
-    Get the indent of the file.
-
-    Args:
-
-        line (str) : A string whose indent needs to be found
-
-    Returns:
-
-        int: Indent
-
-    """
-    indent = 0
-    for c in line:
-        if c == " ":
-            indent += 1
-        elif c == "\t":
-            indent += 8
-        else:
-            # break on first word / non-white char
-            break
-    return indent
-
 
 def gen_help(lines: List) -> None:
     """
@@ -62,22 +37,30 @@ def gen_help(lines: List) -> None:
         None
 
     """
-    indent = 0
+    lines_string = ""
+    lines_string += "import argparse"
+    lines_string += "\n"
+    lines_string += "import argmark"
+    lines_string += "\n"
+
     parser_expr = re.compile(r"(\w+)\.parse_args\(")
     for i, line in enumerate(lines):
+        if "ArgumentParser()" in line:
+            firstline = i
         if ".parse_args(" in line:
             parser = re.search(parser_expr, line)
             if parser is not None:
                 lastline = i
                 parser = parser.group(1)
-                indent = get_indent(line)
                 break
-    lines = lines[:lastline]
-    lines.append("\n")
-    lines.append(" " * indent + "import argmark")
-    lines.append(" " * indent + f"argmark.md_help({parser})")
-    logging.debug("\n".join(lines))
-    exec("\n".join(lines), {"__name__": "__main__"})
+
+    lines = lines[firstline:lastline]
+    
+    lines_string += cleandoc("\n".join(lines))
+    lines_string += "\n"
+    lines_string += f"argmark.md_help({parser})"
+    logging.debug(lines_string)
+    exec(lines_string, {"__name__": "__main__"})
 
 
 def md_help(parser: _argparse.ArgumentParser) -> None:

--- a/argmark/argmark.py
+++ b/argmark/argmark.py
@@ -26,7 +26,7 @@ def inline_code(code: str) -> str:
 
 def gen_help(lines: List) -> None:
     """
-    Generate the help given the source code as list of lines
+    Generate lines of code containing the argument parser and pass it to md_help.
 
     Args:
 
@@ -45,7 +45,7 @@ def gen_help(lines: List) -> None:
 
     parser_expr = re.compile(r"(\w+)\.parse_args\(")
     for i, line in enumerate(lines):
-        if "ArgumentParser()" in line:
+        if "ArgumentParser(" in line:
             firstline = i
         if ".parse_args(" in line:
             parser = re.search(parser_expr, line)
@@ -65,7 +65,7 @@ def gen_help(lines: List) -> None:
 
 def md_help(parser: _argparse.ArgumentParser) -> None:
     """
-
+    Generate a mardown file from the given argument parser.
     Args:
         parser: parser object
 

--- a/tests/test_argmark.py
+++ b/tests/test_argmark.py
@@ -10,11 +10,6 @@ def test_inline_code():
     assert inline_code("f") == "`f`"
 
 
-def test_get_indent():
-    assert get_indent("  foo") == 2
-    assert get_indent("\tfoo") == 8
-
-
 def test_gen_help():
     py_file = os.path.join(_install_dir, "sample_argparse.py")
     md_file = "sample_argparse.md"


### PR DESCRIPTION
Currently, the code selection is done by taking all lines up to the line containing `.parse_args(`. If the code before this line includes module imports that argmark can not access or if the parser is constructed inside a method (as is the case in #6 ), no Markdown will be generated. This PR selects part of the code from `Argument Parser(` until `.parse_args(` and uses only this to construct the parser.